### PR TITLE
Implement error handling on MainScreen

### DIFF
--- a/app/src/main/java/jp/co/yumemi/droidtraining/MainActivity.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/MainActivity.kt
@@ -33,6 +33,8 @@ class MainActivity : AppCompatActivity() {
 
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+            // LaunchedEffect は Dispatch が必要なので、起動時は DisposableEffect の方が若干早く実行される（らしい）
+            // FYI: https://github.com/android/nowinandroid/pull/330/files#r999831539
             DisposableEffect(shouldUseDarkTheme) {
                 enableEdgeToEdge(
                     statusBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT) { shouldUseDarkTheme },

--- a/app/src/main/java/jp/co/yumemi/droidtraining/MainActivity.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/MainActivity.kt
@@ -51,6 +51,8 @@ class MainActivity : AppCompatActivity() {
                 MainScreen(
                     modifier = Modifier.fillMaxSize(),
                     uiState = uiState,
+                    viewEvent = viewEvent,
+                    onResetViewEvent = viewModel::resetViewEvent,
                     onClickReload = viewModel::reloadWeather,
                     onClickNext = { /* do noting */ },
                 )

--- a/app/src/main/java/jp/co/yumemi/droidtraining/MainActivity.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/MainActivity.kt
@@ -32,6 +32,7 @@ class MainActivity : AppCompatActivity() {
             val darkScrim = Color.argb(0x80, 0x1b, 0x1b, 0x1b)
 
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+            val viewEvent by viewModel.viewEvent.collectAsStateWithLifecycle(MainWeatherViewEvent.Idle)
 
             // LaunchedEffect は Dispatch が必要なので、起動時は DisposableEffect の方が若干早く実行される（らしい）
             // FYI: https://github.com/android/nowinandroid/pull/330/files#r999831539

--- a/app/src/main/java/jp/co/yumemi/droidtraining/MainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/MainViewModel.kt
@@ -40,6 +40,12 @@ class MainViewModel(
             }
         }
     }
+
+    fun resetViewEvent() {
+        viewModelScope.launch {
+            _viewEvent.send(MainWeatherViewEvent.Idle)
+        }
+    }
 }
 
 @Stable

--- a/app/src/main/java/jp/co/yumemi/droidtraining/MainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/MainViewModel.kt
@@ -6,8 +6,10 @@ import androidx.lifecycle.viewModelScope
 import jp.co.yumemi.droidtraining.core.common.suspendRunCatching
 import jp.co.yumemi.droidtraining.core.datasource.YumemiWeather
 import jp.co.yumemi.droidtraining.core.model.Weather
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import org.koin.android.annotation.KoinViewModel
 
@@ -17,12 +19,15 @@ class MainViewModel(
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(MainWeatherUiState())
+    private val _viewEvent = Channel<MainWeatherViewEvent>(Channel.BUFFERED)
+
     val uiState = _uiState.asStateFlow()
+    val viewEvent = _viewEvent.receiveAsFlow()
 
     fun reloadWeather() {
         viewModelScope.launch {
             suspendRunCatching {
-                val text = yumemiWeather.fetchSimpleWeather()
+                val text = yumemiWeather.fetchThrowsWeather()
                 val weather = Weather.fromString(text)
 
                 MainWeatherUiState(
@@ -30,6 +35,8 @@ class MainViewModel(
                 )
             }.onSuccess {
                 _uiState.value = it
+            }.onFailure {
+                _viewEvent.send(MainWeatherViewEvent.ShowError)
             }
         }
     }
@@ -39,3 +46,9 @@ class MainViewModel(
 data class MainWeatherUiState(
     val weather: Weather = Weather.Sunny,
 )
+
+@Stable
+sealed interface MainWeatherViewEvent {
+    data object Idle : MainWeatherViewEvent
+    data object ShowError : MainWeatherViewEvent
+}

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/MainScreen.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/MainScreen.kt
@@ -4,11 +4,17 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import jp.co.yumemi.droidtraining.MainWeatherUiState
+import jp.co.yumemi.droidtraining.MainWeatherViewEvent
 import jp.co.yumemi.droidtraining.core.model.Weather
 import jp.co.yumemi.droidtraining.core.ui.YumemiTheme
 import jp.co.yumemi.droidtraining.core.ui.extensions.ComponentPreviews
@@ -16,10 +22,22 @@ import jp.co.yumemi.droidtraining.core.ui.extensions.ComponentPreviews
 @Composable
 internal fun MainScreen(
     uiState: MainWeatherUiState,
+    viewEvent: MainWeatherViewEvent,
     onClickReload: () -> Unit,
     onClickNext: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var isDisplayedError by remember { mutableStateOf(false) }
+
+    LaunchedEffect(viewEvent) {
+        when (viewEvent) {
+            MainWeatherViewEvent.Idle -> Unit
+            MainWeatherViewEvent.ShowError -> {
+                isDisplayedError = true
+            }
+        }
+    }
+
     Scaffold(modifier) {
         ConstraintLayout(
             modifier = Modifier
@@ -64,6 +82,7 @@ private fun MainScreenPreview() {
         MainScreen(
             modifier = Modifier.fillMaxSize(),
             uiState = MainWeatherUiState(weather = Weather.Snowy),
+            viewEvent = MainWeatherViewEvent.Idle,
             onClickReload = {},
             onClickNext = {},
         )

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/MainScreen.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/MainScreen.kt
@@ -10,19 +10,23 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import jp.co.yumemi.droidtraining.MainWeatherUiState
 import jp.co.yumemi.droidtraining.MainWeatherViewEvent
+import jp.co.yumemi.droidtraining.R
 import jp.co.yumemi.droidtraining.core.model.Weather
 import jp.co.yumemi.droidtraining.core.ui.YumemiTheme
+import jp.co.yumemi.droidtraining.core.ui.components.SimpleAlertDialog
 import jp.co.yumemi.droidtraining.core.ui.extensions.ComponentPreviews
 
 @Composable
 internal fun MainScreen(
     uiState: MainWeatherUiState,
     viewEvent: MainWeatherViewEvent,
+    onResetViewEvent: () -> Unit,
     onClickReload: () -> Unit,
     onClickNext: () -> Unit,
     modifier: Modifier = Modifier,
@@ -73,6 +77,22 @@ internal fun MainScreen(
             )
         }
     }
+
+    if (isDisplayedError) {
+        SimpleAlertDialog(
+            title = stringResource(R.string.error_title_common),
+            message = stringResource(R.string.error_message_common),
+            positiveButtonText = stringResource(R.string.main_weather_action_reload),
+            negativeButtonText = stringResource(R.string.close),
+            onPositiveButtonClick = {
+                onClickReload.invoke()
+            },
+            onDismissRequest = {
+                onResetViewEvent.invoke()
+                isDisplayedError = false
+            },
+        )
+    }
 }
 
 @ComponentPreviews
@@ -83,6 +103,7 @@ private fun MainScreenPreview() {
             modifier = Modifier.fillMaxSize(),
             uiState = MainWeatherUiState(weather = Weather.Snowy),
             viewEvent = MainWeatherViewEvent.Idle,
+            onResetViewEvent = {},
             onClickReload = {},
             onClickNext = {},
         )

--- a/core/common/src/main/java/jp/co/yumemi/droidtraining/core/common/CoroutineUtils.kt
+++ b/core/common/src/main/java/jp/co/yumemi/droidtraining/core/common/CoroutineUtils.kt
@@ -7,7 +7,7 @@ suspend fun <T> suspendRunCatching(block: suspend () -> T): Result<T> = try {
     Result.success(block())
 } catch (cancellationException: CancellationException) {
     throw cancellationException
-} catch (exception: Exception) {
-    Log.w("SuspendRunCatching", "Failed to evaluate a suspendRunCatchingBlock. Returning failure Result", exception)
-    Result.failure(exception)
+} catch (throwable: Throwable) {
+    Log.w("SuspendRunCatching", "Failed to evaluate a suspendRunCatchingBlock. Returning failure Result", throwable)
+    Result.failure(throwable)
 }

--- a/core/ui/src/main/java/jp/co/yumemi/droidtraining/core/ui/components/SimpleAlertDialog.kt
+++ b/core/ui/src/main/java/jp/co/yumemi/droidtraining/core/ui/components/SimpleAlertDialog.kt
@@ -1,0 +1,85 @@
+package jp.co.yumemi.droidtraining.core.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import jp.co.yumemi.droidtraining.core.ui.YumemiTheme
+import jp.co.yumemi.droidtraining.core.ui.extensions.ComponentPreviews
+
+@Composable
+fun SimpleAlertDialog(
+    title: String? = null,
+    message: String? = null,
+    positiveButtonText: String? = null,
+    negativeButtonText: String? = null,
+    onPositiveButtonClick: () -> Unit = {},
+    onNegativeButtonClick: () -> Unit = {},
+    onDismissRequest: () -> Unit,
+) {
+    AlertDialog(
+        title = title?.letComposable {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        },
+        text = message?.letComposable {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            if (positiveButtonText != null) {
+                TextButton(
+                    onClick = {
+                        onPositiveButtonClick.invoke()
+                        onDismissRequest.invoke()
+                    }
+                ) {
+                    Text(positiveButtonText)
+                }
+            }
+        },
+        dismissButton = {
+            if (negativeButtonText != null) {
+                TextButton(
+                    onClick = {
+                        onNegativeButtonClick.invoke()
+                        onDismissRequest.invoke()
+                    },
+                ) {
+                    Text(negativeButtonText)
+                }
+            }
+        },
+        onDismissRequest = onDismissRequest,
+    )
+}
+
+private fun <T> (T).letComposable(f: @Composable (T) -> Unit): (@Composable () -> Unit)? {
+    return run {
+        {
+            f(this)
+        }
+    }
+}
+
+@ComponentPreviews
+@Composable
+private fun SimpleAlertDialogPreview() {
+    YumemiTheme {
+        SimpleAlertDialog(
+            title = "Title",
+            message = "Message",
+            positiveButtonText = "Positive",
+            negativeButtonText = "Negative",
+            onPositiveButtonClick = {},
+            onNegativeButtonClick = {},
+            onDismissRequest = {},
+        )
+    }
+}
+

--- a/core/ui/src/main/java/jp/co/yumemi/droidtraining/core/ui/components/SimpleAlertDialog.kt
+++ b/core/ui/src/main/java/jp/co/yumemi/droidtraining/core/ui/components/SimpleAlertDialog.kt
@@ -1,68 +1,99 @@
 package jp.co.yumemi.droidtraining.core.ui.components
 
-import androidx.compose.material3.AlertDialog
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import jp.co.yumemi.droidtraining.core.ui.YumemiTheme
+import jp.co.yumemi.droidtraining.core.ui.bold
 import jp.co.yumemi.droidtraining.core.ui.extensions.ComponentPreviews
 
 @Composable
 fun SimpleAlertDialog(
-    title: String? = null,
-    message: String? = null,
+    title: String,
+    message: String,
     positiveButtonText: String? = null,
     negativeButtonText: String? = null,
     onPositiveButtonClick: () -> Unit = {},
     onNegativeButtonClick: () -> Unit = {},
+    isCaution: Boolean = false,
     onDismissRequest: () -> Unit,
 ) {
-    AlertDialog(
-        title = title?.letComposable {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.titleMedium,
-            )
-        },
-        text = message?.letComposable {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.bodyMedium,
-            )
-        },
-        confirmButton = {
-            if (positiveButtonText != null) {
-                TextButton(
-                    onClick = {
-                        onPositiveButtonClick.invoke()
-                        onDismissRequest.invoke()
-                    }
-                ) {
-                    Text(positiveButtonText)
-                }
-            }
-        },
-        dismissButton = {
-            if (negativeButtonText != null) {
-                TextButton(
-                    onClick = {
-                        onNegativeButtonClick.invoke()
-                        onDismissRequest.invoke()
-                    },
-                ) {
-                    Text(negativeButtonText)
-                }
-            }
-        },
+    Dialog(
         onDismissRequest = onDismissRequest,
-    )
-}
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .clip(RoundedCornerShape(16.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = title,
+                style = MaterialTheme.typography.titleMedium.bold(),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
 
-private fun <T> (T).letComposable(f: @Composable (T) -> Unit): (@Composable () -> Unit)? {
-    return run {
-        {
-            f(this)
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Row(
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (negativeButtonText != null) {
+                    OutlinedButton(
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(4.dp),
+                        onClick = {
+                            onNegativeButtonClick.invoke()
+                            onDismissRequest.invoke()
+                        },
+                    ) {
+                        Text(text = negativeButtonText)
+                    }
+                }
+
+                if (positiveButtonText != null) {
+                    Button(
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(4.dp),
+                        colors = ButtonDefaults.buttonColors(if (isCaution) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary),
+                        onClick = {
+                            onPositiveButtonClick.invoke()
+                            onDismissRequest.invoke()
+                        },
+                    ) {
+                        Text(text = positiveButtonText)
+                    }
+                }
+            }
         }
     }
 }
@@ -76,8 +107,21 @@ private fun SimpleAlertDialogPreview() {
             message = "Message",
             positiveButtonText = "Positive",
             negativeButtonText = "Negative",
-            onPositiveButtonClick = {},
-            onNegativeButtonClick = {},
+            onDismissRequest = {},
+        )
+    }
+}
+
+@ComponentPreviews
+@Composable
+private fun SimpleAlertDialogPreviewCaution() {
+    YumemiTheme {
+        SimpleAlertDialog(
+            title = "Title",
+            message = "Message",
+            positiveButtonText = "Positive",
+            negativeButtonText = "Negative",
+            isCaution = true,
             onDismissRequest = {},
         )
     }

--- a/core/ui/src/main/java/jp/co/yumemi/droidtraining/core/ui/components/SimpleAlertDialog.kt
+++ b/core/ui/src/main/java/jp/co/yumemi/droidtraining/core/ui/components/SimpleAlertDialog.kt
@@ -23,6 +23,7 @@ import jp.co.yumemi.droidtraining.core.ui.YumemiTheme
 import jp.co.yumemi.droidtraining.core.ui.bold
 import jp.co.yumemi.droidtraining.core.ui.extensions.ComponentPreviews
 
+@Suppress("ModifierMissing")
 @Composable
 fun SimpleAlertDialog(
     title: String,
@@ -126,4 +127,3 @@ private fun SimpleAlertDialogPreviewCaution() {
         )
     }
 }
-

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- Common -->
+    <string name="close">Close</string>
+
     <!-- Main -->
     <string name="main_weather_action_reload">Reload</string>
     <string name="main_weather_action_next">Next</string>
+
+    <!-- Error -->
+    <string name="error_title_common">Error</string>
+    <string name="error_message_common">An error has occurred.</string>
 </resources>


### PR DESCRIPTION
## 修正内容
- closes #12 
- 汎用ダイアログである `SimpleAlertDialog` を追加しました
  - Figma による指定は特に無かったのと、Material3 の `AlertDialog` のデザインが好みではないので自作しました
- ViewEvent 方式による UI <-> ViewModel 間の通信を実装しました
- `suspendRunCatching` が Throwable もキャッチできるように変更しました

## レビューレベルの設定
- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [x] ぱっとみて違和感がないかチェックしてApproveする
- [ ] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点
- ダイアログの UI を変更しているが良いか
- エラーハンドリングの仕方
- UI <-> ViewModel 間の通信の仕方

## スクリーンショット
| After |
| - |
|<video src=https://github.com/user-attachments/assets/2a7f7f04-94ef-4b90-9a2e-649c2e92206b>|

## 備考
- N/A
