### PR TITLE
Integrate open weather map api

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,16 @@ Androidアプリ開発の基礎復習・実務スキルを身に付けるため�
 
 このAndroidプロジェクトは[android-training-template](https://github.com/yumemi-inc/android-training-template)からセットアップされました.  
 課題の詳細や進め方は元のリポジトリのREADMEを参照してください.
+
+# セットアップ
+
+このアプリは OpenWeatherMap API を利用して天気情報を取得するため、APIキーが必要です。
+[OpenWeatherMap](https://home.openweathermap.org/users/sign_up)にアカウント登録を行い、APIキーを取得してください。
+
+
+取得した APIキーを `local.properties` に以下のように設定してください。
+ここで設定した値が BuildConfig に反映され、`YumemiConfig` として DI 可能になります。
+
+```
+OPEN_WEATHER_MAP_API_KEY="YOUR_API_KEY"
+```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,7 +45,7 @@ fun MapProperty<String, BuildConfigField<out Serializable>>.putBuildConfig(
     value: String? = null,
     type: String = "String",
     defaultValue: String = "",
-    comment: String? = null
+    comment: String? = null,
 ) {
     val property = localProperties.getProperty(key)
     val env = System.getenv(key)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.android.build.api.variant.BuildConfigField
+import org.jetbrains.kotlin.konan.properties.Properties
+import java.io.Serializable
+
 plugins {
     id("yumemi.primitive.android.application")
     id("yumemi.primitive.detekt")
@@ -6,7 +10,18 @@ plugins {
 }
 
 android {
+    val file = project.rootDir.resolve("local.properties")
+    val localProperties = Properties().apply {
+        if (file.exists()) load(file.inputStream())
+    }
+
     namespace = "jp.co.yumemi.droidtraining"
+
+    androidComponents {
+        onVariants {
+            it.buildConfigFields.putBuildConfig(localProperties, "OPEN_WEATHER_MAP_API_KEY")
+        }
+    }
 }
 
 dependencies {
@@ -22,4 +37,23 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso)
+}
+
+fun MapProperty<String, BuildConfigField<out Serializable>>.putBuildConfig(
+    localProperties: Properties,
+    key: String,
+    value: String? = null,
+    type: String = "String",
+    defaultValue: String = "",
+    comment: String? = null
+) {
+    val property = localProperties.getProperty(key)
+    val env = System.getenv(key)
+
+    put(key, BuildConfigField(type, (value ?: property ?: env ?: defaultValue).toStringLiteral(), comment))
+}
+
+fun Any.toStringLiteral(): String {
+    val value = toString()
+    return if (value.firstOrNull() == '\"' && value.lastOrNull() == '\"') value else "\"$value\""
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="jp.co.yumemi.droidtraining">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".YumemiApplication"
         android:allowBackup="true"

--- a/app/src/main/java/jp/co/yumemi/droidtraining/MainActivity.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/MainActivity.kt
@@ -54,7 +54,7 @@ class MainActivity : AppCompatActivity() {
                     screenState = screenState,
                     onResetViewEvent = viewModel::resetScreenState,
                     onClickReload = viewModel::reloadWeather,
-                    onClickNext = { /* do noting */ },
+                    onClickNext = viewModel::nextWeather,
                 )
             }
         }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/MainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/MainViewModel.kt
@@ -23,12 +23,26 @@ class MainViewModel(
     val uiState = _uiState.asStateFlow()
     val screenState = _screenState.asStateFlow()
 
-    fun reloadWeather() {
+    fun reloadWeather(currentArea: Area?) {
         viewModelScope.launch {
             _screenState.value = MainWeatherScreenState.Loading
             _screenState.value = suspendRunCatching {
                 _uiState.value = MainWeatherUiState(
-                    weather = weatherRepository.fetchWeather(Area.TOKYO),
+                    weather = weatherRepository.fetchWeather(currentArea ?: Area.TOKYO),
+                )
+            }.fold(
+                onSuccess = { MainWeatherScreenState.Idle },
+                onFailure = { MainWeatherScreenState.Error },
+            )
+        }
+    }
+
+    fun nextWeather(currentArea: Area?) {
+        viewModelScope.launch {
+            _screenState.value = MainWeatherScreenState.Loading
+            _screenState.value = suspendRunCatching {
+                _uiState.value = MainWeatherUiState(
+                    weather = weatherRepository.fetchWeather(currentArea?.let { Area.next(it) } ?: Area.TOKYO),
                 )
             }.fold(
                 onSuccess = { MainWeatherScreenState.Idle },

--- a/app/src/main/java/jp/co/yumemi/droidtraining/MainViewModel.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/MainViewModel.kt
@@ -3,10 +3,9 @@ package jp.co.yumemi.droidtraining
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import jp.co.yumemi.droidtraining.core.common.serializer.toInstantInTokyo
 import jp.co.yumemi.droidtraining.core.common.suspendRunCatching
+import jp.co.yumemi.droidtraining.core.model.Area
 import jp.co.yumemi.droidtraining.core.model.WeatherDetail
-import jp.co.yumemi.droidtraining.core.model.WeatherRequest
 import jp.co.yumemi.droidtraining.core.repository.YumemiWeatherRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -28,11 +27,8 @@ class MainViewModel(
         viewModelScope.launch {
             _screenState.value = MainWeatherScreenState.Loading
             _screenState.value = suspendRunCatching {
-                val request = WeatherRequest("tokyo", "2020-04-01T12:00".toInstantInTokyo())
-                val result = weatherRepository.fetchWeather(request)
-
                 _uiState.value = MainWeatherUiState(
-                    weather = result,
+                    weather = weatherRepository.fetchWeather(Area.TOKYO),
                 )
             }.fold(
                 onSuccess = { MainWeatherScreenState.Idle },

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/MainScreen.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/MainScreen.kt
@@ -120,7 +120,7 @@ internal fun MainScreen(
 }
 
 private enum class ButtonType {
-    RELOAD, NEXT;
+    RELOAD, NEXT
 }
 
 @ComponentPreviews

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/MainScreen.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/MainScreen.kt
@@ -6,6 +6,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -14,6 +18,7 @@ import androidx.constraintlayout.compose.Dimension
 import jp.co.yumemi.droidtraining.MainWeatherScreenState
 import jp.co.yumemi.droidtraining.MainWeatherUiState
 import jp.co.yumemi.droidtraining.R
+import jp.co.yumemi.droidtraining.core.model.Area
 import jp.co.yumemi.droidtraining.core.ui.YumemiTheme
 import jp.co.yumemi.droidtraining.core.ui.components.LoadingScreen
 import jp.co.yumemi.droidtraining.core.ui.components.SimpleAlertDialog
@@ -25,10 +30,12 @@ internal fun MainScreen(
     uiState: MainWeatherUiState,
     screenState: MainWeatherScreenState,
     onResetViewEvent: () -> Unit,
-    onClickReload: () -> Unit,
-    onClickNext: () -> Unit,
+    onClickReload: (Area?) -> Unit,
+    onClickNext: (Area?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var lastClickedButtonType by remember { mutableStateOf(ButtonType.RELOAD) }
+
     Scaffold(modifier) {
         Box {
             ConstraintLayout(
@@ -72,8 +79,14 @@ internal fun MainScreen(
                             height = Dimension.wrapContent
                         }
                     },
-                    onClickReload = onClickReload,
-                    onClickNext = onClickNext,
+                    onClickReload = {
+                        lastClickedButtonType = ButtonType.RELOAD
+                        onClickReload.invoke(uiState.weather?.area)
+                    },
+                    onClickNext = {
+                        lastClickedButtonType = ButtonType.NEXT
+                        onClickNext.invoke(uiState.weather?.area)
+                    },
                 )
             }
 
@@ -94,11 +107,20 @@ internal fun MainScreen(
             message = stringResource(R.string.error_message_common),
             positiveButtonText = stringResource(R.string.main_weather_action_reload),
             negativeButtonText = stringResource(R.string.close),
-            onPositiveButtonClick = onClickReload,
+            onPositiveButtonClick = {
+                when (lastClickedButtonType) {
+                    ButtonType.RELOAD -> onClickReload(uiState.weather?.area)
+                    ButtonType.NEXT -> onClickNext(uiState.weather?.area)
+                }
+            },
             onNegativeButtonClick = onResetViewEvent,
             onDismissRequest = onResetViewEvent,
         )
     }
+}
+
+private enum class ButtonType {
+    RELOAD, NEXT;
 }
 
 @ComponentPreviews

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/MainWeatherInfoSection.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/MainWeatherInfoSection.kt
@@ -42,7 +42,7 @@ internal fun MainWeatherInfoSection(
     ) {
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = weather.area,
+            text = weather.areaName,
             style = MaterialTheme.typography.titleMedium.bold().center(),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/MainWeatherInfoSection.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/MainWeatherInfoSection.kt
@@ -33,6 +33,7 @@ internal fun MainWeatherInfoSection(
         Weather.Cloudy -> R.drawable.vec_cloudy
         Weather.Rainy -> R.drawable.vec_rainy
         Weather.Snowy -> R.drawable.vec_snowy
+        else -> null
     }
 
     Column(
@@ -46,25 +47,27 @@ internal fun MainWeatherInfoSection(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
-        Image(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(1f),
-            painter = painterResource(weatherIcon),
-            contentDescription = "Weather Icon",
-        )
+        if (weatherIcon != null) {
+            Image(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f),
+                painter = painterResource(weatherIcon),
+                contentDescription = "Weather Icon",
+            )
+        }
 
         Row {
             Text(
                 modifier = Modifier.weight(1f),
-                text = "${weather.minTemp}℃",
+                text = "%.2f℃".format(weather.minTemp),
                 style = MaterialTheme.typography.bodyMedium.center(),
                 color = Color.Blue,
             )
 
             Text(
                 modifier = Modifier.weight(1f),
-                text = "${weather.maxTemp}℃",
+                text = "%.2f℃".format(weather.maxTemp),
                 style = MaterialTheme.typography.bodyMedium.center(),
                 color = Color.Red,
             )

--- a/app/src/main/java/jp/co/yumemi/droidtraining/di/AppModule.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/di/AppModule.kt
@@ -1,5 +1,7 @@
 package jp.co.yumemi.droidtraining.di
 
+import jp.co.yumemi.droidtraining.BuildConfig
+import jp.co.yumemi.droidtraining.core.model.YumemiConfig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import org.koin.core.annotation.ComponentScan
@@ -19,4 +21,9 @@ class AppModule {
     @Single
     @Named("mainDispatcher")
     fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+
+    @Single
+    fun provideYumemiConfig() = YumemiConfig(
+        openWeatherMapApiKey = BuildConfig.OPEN_WEATHER_MAP_API_KEY,
+    )
 }

--- a/core/datasource/build.gradle.kts
+++ b/core/datasource/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
     implementation(libs.moshi)
     ksp(libs.moshi.codegen)
 
+    // Ktor
+    implementation(libs.bundles.ktor)
+
     // Test
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/core/datasource/src/main/java/jp/co/yumemi/droidtraining/core/datasource/YumemiWeatherSource.kt
+++ b/core/datasource/src/main/java/jp/co/yumemi/droidtraining/core/datasource/YumemiWeatherSource.kt
@@ -1,11 +1,37 @@
 package jp.co.yumemi.droidtraining.core.datasource
 
-import kotlinx.serialization.json.Json
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.request.url
+import jp.co.yumemi.droidtraining.core.model.Area
+import jp.co.yumemi.droidtraining.core.model.YumemiConfig
+import jp.co.yumemi.droidtraining.core.model.entity.WeatherDetailEntity
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 
 @Single
 class YumemiWeatherSource(
-    private val formatter: Json,
+    private val client: HttpClient,
+    @Provided private val config: YumemiConfig,
 ) {
-    
+    suspend fun fetchWeather(area: Area): WeatherDetailEntity {
+        return client.get {
+            url("$API/weather")
+            parameter("id", area.id)
+            defaultParameters()
+        }.body()
+    }
+
+    private fun HttpRequestBuilder.defaultParameters() {
+        parameter("appid", config.openWeatherMapApiKey)
+        parameter("lang", "ja")
+        parameter("units", "metric")
+    }
+
+    companion object {
+        private const val API = "https://api.openweathermap.org/data/2.5"
+    }
 }

--- a/core/datasource/src/main/java/jp/co/yumemi/droidtraining/core/datasource/YumemiWeatherSource.kt
+++ b/core/datasource/src/main/java/jp/co/yumemi/droidtraining/core/datasource/YumemiWeatherSource.kt
@@ -1,0 +1,11 @@
+package jp.co.yumemi.droidtraining.core.datasource
+
+import kotlinx.serialization.json.Json
+import org.koin.core.annotation.Single
+
+@Single
+class YumemiWeatherSource(
+    private val formatter: Json,
+) {
+    
+}

--- a/core/datasource/src/main/java/jp/co/yumemi/droidtraining/core/datasource/di/DataSourceModule.kt
+++ b/core/datasource/src/main/java/jp/co/yumemi/droidtraining/core/datasource/di/DataSourceModule.kt
@@ -1,5 +1,9 @@
 package jp.co.yumemi.droidtraining.core.datasource.di
 
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
@@ -19,5 +23,17 @@ class DataSourceModule {
         coerceInputValues = true
         encodeDefaults = true
         explicitNulls = false
+    }
+
+    @Single
+    fun provideHttpClient() = HttpClient {
+        install(ContentNegotiation) {
+            json(provideJsonFormatter())
+        }
+
+        install(HttpRequestRetry) {
+            maxRetries = 3
+            exponentialDelay()
+        }
     }
 }

--- a/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/Area.kt
+++ b/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/Area.kt
@@ -1,0 +1,28 @@
+package jp.co.yumemi.droidtraining.core.model
+
+enum class Area(val id: Int) {
+    SAPPORO(2128295),
+    KUSHIRO(2129376),
+    SENDAI(2111149),
+    NIIGATA(1855431),
+    TOKYO(1850144),
+    NAGOYA(1856057),
+    KANAZAWA(1860243),
+    OSAKA(1853909),
+    HIROSHIMA(1862415),
+    KOCHI(1859146),
+    FUKUOKA(1863967),
+    KAGOSHIMA(1860827),
+    NAHA(1856035),
+    NEW_YORK(5128581),
+    LONDON(2643743),
+    UNKNOWN(-1);
+
+    companion object {
+        fun fromId(id: Int): Area {
+            return entries.find { it.id == id } ?: UNKNOWN
+        }
+    }
+}
+
+

--- a/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/Area.kt
+++ b/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/Area.kt
@@ -1,6 +1,6 @@
 package jp.co.yumemi.droidtraining.core.model
 
-enum class Area(val id: Int) {
+enum class Area(val id: Long) {
     SAPPORO(2128295),
     KUSHIRO(2129376),
     SENDAI(2111149),
@@ -20,8 +20,14 @@ enum class Area(val id: Int) {
     ;
 
     companion object {
-        fun fromId(id: Int): Area {
+        fun fromId(id: Long): Area {
             return entries.find { it.id == id } ?: UNKNOWN
+        }
+
+        fun next(currentArea: Area): Area {
+            val areas = entries.toMutableList().apply { remove(UNKNOWN) }
+            val nextIndex = (currentArea.ordinal + 1) % areas.size
+            return areas[nextIndex]
         }
     }
 }

--- a/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/Area.kt
+++ b/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/Area.kt
@@ -16,7 +16,8 @@ enum class Area(val id: Int) {
     NAHA(1856035),
     NEW_YORK(5128581),
     LONDON(2643743),
-    UNKNOWN(-1);
+    UNKNOWN(-1),
+    ;
 
     companion object {
         fun fromId(id: Int): Area {
@@ -24,5 +25,3 @@ enum class Area(val id: Int) {
         }
     }
 }
-
-

--- a/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/Weather.kt
+++ b/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/Weather.kt
@@ -1,19 +1,12 @@
 package jp.co.yumemi.droidtraining.core.model
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 enum class Weather {
-    @SerialName("sunny")
     Sunny,
-
-    @SerialName("cloudy")
     Cloudy,
-
-    @SerialName("rainy")
     Rainy,
-
-    @SerialName("snow")
     Snowy,
+    Unknown,
 }

--- a/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/WeatherDetail.kt
+++ b/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/WeatherDetail.kt
@@ -11,5 +11,6 @@ data class WeatherDetail(
     val minTemp: Double,
     @Serializable(with = InstantSerializer::class)
     val date: Instant,
-    val area: String,
+    val area: Area,
+    val areaName: String,
 )

--- a/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/WeatherDetail.kt
+++ b/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/WeatherDetail.kt
@@ -7,8 +7,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class WeatherDetail(
     val weather: Weather,
-    val maxTemp: Int,
-    val minTemp: Int,
+    val maxTemp: Double,
+    val minTemp: Double,
     @Serializable(with = InstantSerializer::class)
     val date: Instant,
     val area: String,

--- a/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/YumemiConfig.kt
+++ b/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/YumemiConfig.kt
@@ -1,0 +1,5 @@
+package jp.co.yumemi.droidtraining.core.model
+
+data class YumemiConfig(
+    val openWeatherMapApiKey: String,
+)

--- a/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/entity/WeatherDetailEntity.kt
+++ b/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/entity/WeatherDetailEntity.kt
@@ -1,6 +1,5 @@
 package jp.co.yumemi.droidtraining.core.model.entity
 
-
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -33,12 +32,12 @@ data class WeatherDetailEntity(
     @SerialName("weather")
     val weather: List<Weather>,
     @SerialName("wind")
-    val wind: Wind
+    val wind: Wind,
 ) {
     @Serializable
     data class Clouds(
         @SerialName("all")
-        val all: Int
+        val all: Int,
     )
 
     @Serializable
@@ -46,7 +45,7 @@ data class WeatherDetailEntity(
         @SerialName("lat")
         val lat: Double,
         @SerialName("lon")
-        val lon: Double
+        val lon: Double,
     )
 
     @Serializable
@@ -66,13 +65,13 @@ data class WeatherDetailEntity(
         @SerialName("temp_max")
         val tempMax: Double,
         @SerialName("temp_min")
-        val tempMin: Double
+        val tempMin: Double,
     )
 
     @Serializable
     data class Rain(
         @SerialName("1h")
-        val h: Double
+        val h: Double,
     )
 
     @Serializable
@@ -86,7 +85,7 @@ data class WeatherDetailEntity(
         @SerialName("sunset")
         val sunset: Int,
         @SerialName("type")
-        val type: Int
+        val type: Int,
     )
 
     @Serializable
@@ -98,7 +97,7 @@ data class WeatherDetailEntity(
         @SerialName("id")
         val id: Long,
         @SerialName("main")
-        val main: String
+        val main: String,
     )
 
     @Serializable
@@ -106,6 +105,6 @@ data class WeatherDetailEntity(
         @SerialName("deg")
         val deg: Int,
         @SerialName("speed")
-        val speed: Double
+        val speed: Double,
     )
 }

--- a/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/entity/WeatherDetailEntity.kt
+++ b/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/entity/WeatherDetailEntity.kt
@@ -1,0 +1,111 @@
+package jp.co.yumemi.droidtraining.core.model.entity
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeatherDetailEntity(
+    @SerialName("base")
+    val base: String,
+    @SerialName("clouds")
+    val clouds: Clouds,
+    @SerialName("cod")
+    val cod: Long,
+    @SerialName("coord")
+    val coord: Coord,
+    @SerialName("dt")
+    val dt: Long,
+    @SerialName("id")
+    val id: Long,
+    @SerialName("main")
+    val main: Main,
+    @SerialName("name")
+    val name: String,
+    @SerialName("rain")
+    val rain: Rain,
+    @SerialName("sys")
+    val sys: Sys,
+    @SerialName("timezone")
+    val timezone: Int,
+    @SerialName("visibility")
+    val visibility: Int,
+    @SerialName("weather")
+    val weather: List<Weather>,
+    @SerialName("wind")
+    val wind: Wind
+) {
+    @Serializable
+    data class Clouds(
+        @SerialName("all")
+        val all: Int
+    )
+
+    @Serializable
+    data class Coord(
+        @SerialName("lat")
+        val lat: Double,
+        @SerialName("lon")
+        val lon: Double
+    )
+
+    @Serializable
+    data class Main(
+        @SerialName("feels_like")
+        val feelsLike: Double,
+        @SerialName("grnd_level")
+        val grndLevel: Int,
+        @SerialName("humidity")
+        val humidity: Int,
+        @SerialName("pressure")
+        val pressure: Int,
+        @SerialName("sea_level")
+        val seaLevel: Int,
+        @SerialName("temp")
+        val temp: Double,
+        @SerialName("temp_max")
+        val tempMax: Double,
+        @SerialName("temp_min")
+        val tempMin: Double
+    )
+
+    @Serializable
+    data class Rain(
+        @SerialName("1h")
+        val h: Double
+    )
+
+    @Serializable
+    data class Sys(
+        @SerialName("country")
+        val country: String,
+        @SerialName("id")
+        val id: Int,
+        @SerialName("sunrise")
+        val sunrise: Int,
+        @SerialName("sunset")
+        val sunset: Int,
+        @SerialName("type")
+        val type: Int
+    )
+
+    @Serializable
+    data class Weather(
+        @SerialName("description")
+        val description: String,
+        @SerialName("icon")
+        val icon: String,
+        @SerialName("id")
+        val id: Long,
+        @SerialName("main")
+        val main: String
+    )
+
+    @Serializable
+    data class Wind(
+        @SerialName("deg")
+        val deg: Int,
+        @SerialName("speed")
+        val speed: Double
+    )
+}

--- a/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/entity/WeatherDetailEntity.kt
+++ b/core/model/src/main/java/jp/co/yumemi/droidtraining/core/model/entity/WeatherDetailEntity.kt
@@ -22,7 +22,9 @@ data class WeatherDetailEntity(
     @SerialName("name")
     val name: String,
     @SerialName("rain")
-    val rain: Rain,
+    val rain: Rain?,
+    @SerialName("snow")
+    val snow: Snow?,
     @SerialName("sys")
     val sys: Sys,
     @SerialName("timezone")
@@ -71,7 +73,17 @@ data class WeatherDetailEntity(
     @Serializable
     data class Rain(
         @SerialName("1h")
-        val h: Double,
+        val oneHr: Double?,
+        @SerialName("3h")
+        val threeHr: Double?,
+    )
+
+    @Serializable
+    data class Snow(
+        @SerialName("1h")
+        val oneHr: Double?,
+        @SerialName("3h")
+        val threeHr: Double?,
     )
 
     @Serializable
@@ -79,13 +91,13 @@ data class WeatherDetailEntity(
         @SerialName("country")
         val country: String,
         @SerialName("id")
-        val id: Int,
+        val id: Long?,
         @SerialName("sunrise")
         val sunrise: Int,
         @SerialName("sunset")
         val sunset: Int,
         @SerialName("type")
-        val type: Int,
+        val type: Int?,
     )
 
     @Serializable

--- a/core/repository/src/main/java/jp/co/yumemi/droidtraining/core/repository/YumemiWeatherRepository.kt
+++ b/core/repository/src/main/java/jp/co/yumemi/droidtraining/core/repository/YumemiWeatherRepository.kt
@@ -1,24 +1,27 @@
 package jp.co.yumemi.droidtraining.core.repository
 
-import jp.co.yumemi.droidtraining.core.datasource.DummyWeatherWrapperSource
+import jp.co.yumemi.droidtraining.core.datasource.YumemiWeatherSource
+import jp.co.yumemi.droidtraining.core.model.Area
 import jp.co.yumemi.droidtraining.core.model.WeatherDetail
-import jp.co.yumemi.droidtraining.core.model.WeatherRequest
+import jp.co.yumemi.droidtraining.core.repository.mapper.WeatherDetailMapper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 
 interface YumemiWeatherRepository {
-    suspend fun fetchWeather(request: WeatherRequest): WeatherDetail
+    suspend fun fetchWeather(area: Area): WeatherDetail
 }
 
 @Single
 class YumemiWeatherRepositoryImpl(
-    private val weatherSource: DummyWeatherWrapperSource,
+    private val weatherSource: YumemiWeatherSource,
+    private val weatherDetailMapper: WeatherDetailMapper,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : YumemiWeatherRepository {
 
-    override suspend fun fetchWeather(request: WeatherRequest): WeatherDetail = withContext(ioDispatcher) {
-        weatherSource.fetchWeather(request)
+    override suspend fun fetchWeather(area: Area): WeatherDetail = withContext(ioDispatcher) {
+        val entity = weatherSource.fetchWeather(area)
+        weatherDetailMapper.asWeatherDetail(entity)
     }
 }

--- a/core/repository/src/main/java/jp/co/yumemi/droidtraining/core/repository/mapper/WeatherDetailMapper.kt
+++ b/core/repository/src/main/java/jp/co/yumemi/droidtraining/core/repository/mapper/WeatherDetailMapper.kt
@@ -1,0 +1,31 @@
+package jp.co.yumemi.droidtraining.core.repository.mapper
+
+import jp.co.yumemi.droidtraining.core.model.Weather
+import jp.co.yumemi.droidtraining.core.model.WeatherDetail
+import jp.co.yumemi.droidtraining.core.model.entity.WeatherDetailEntity
+import kotlinx.datetime.Instant
+import org.koin.core.annotation.Single
+
+@Single
+class WeatherDetailMapper {
+
+    fun asWeatherDetail(entity: WeatherDetailEntity): WeatherDetail {
+        return WeatherDetail(
+            weather = asWeatherType(entity.weather.first()),
+            maxTemp = entity.main.tempMax,
+            minTemp = entity.main.tempMin,
+            date = Instant.fromEpochSeconds(entity.dt, 0),
+            area = entity.name
+        )
+    }
+
+    private fun asWeatherType(entity: WeatherDetailEntity.Weather): Weather {
+        return when (entity.id) {
+            in 500 until 600 -> Weather.Rainy
+            in 600 until 700 -> Weather.Snowy
+            in 801 until 900 -> Weather.Cloudy
+            800L -> Weather.Sunny
+            else -> Weather.Unknown
+        }
+    }
+}

--- a/core/repository/src/main/java/jp/co/yumemi/droidtraining/core/repository/mapper/WeatherDetailMapper.kt
+++ b/core/repository/src/main/java/jp/co/yumemi/droidtraining/core/repository/mapper/WeatherDetailMapper.kt
@@ -15,7 +15,7 @@ class WeatherDetailMapper {
             maxTemp = entity.main.tempMax,
             minTemp = entity.main.tempMin,
             date = Instant.fromEpochSeconds(entity.dt, 0),
-            area = entity.name
+            area = entity.name,
         )
     }
 

--- a/core/repository/src/main/java/jp/co/yumemi/droidtraining/core/repository/mapper/WeatherDetailMapper.kt
+++ b/core/repository/src/main/java/jp/co/yumemi/droidtraining/core/repository/mapper/WeatherDetailMapper.kt
@@ -1,5 +1,6 @@
 package jp.co.yumemi.droidtraining.core.repository.mapper
 
+import jp.co.yumemi.droidtraining.core.model.Area
 import jp.co.yumemi.droidtraining.core.model.Weather
 import jp.co.yumemi.droidtraining.core.model.WeatherDetail
 import jp.co.yumemi.droidtraining.core.model.entity.WeatherDetailEntity
@@ -15,7 +16,8 @@ class WeatherDetailMapper {
             maxTemp = entity.main.tempMax,
             minTemp = entity.main.tempMin,
             date = Instant.fromEpochSeconds(entity.dt, 0),
-            area = entity.name,
+            area = Area.fromId(entity.id),
+            areaName = entity.name,
         )
     }
 

--- a/core/ui/src/main/java/jp/co/yumemi/droidtraining/core/ui/previews/WeatherResponsePreviewParameter.kt
+++ b/core/ui/src/main/java/jp/co/yumemi/droidtraining/core/ui/previews/WeatherResponsePreviewParameter.kt
@@ -1,6 +1,7 @@
 package jp.co.yumemi.droidtraining.core.ui.previews
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import jp.co.yumemi.droidtraining.core.model.Area
 import jp.co.yumemi.droidtraining.core.model.Weather
 import jp.co.yumemi.droidtraining.core.model.WeatherDetail
 import kotlinx.datetime.Instant
@@ -12,15 +13,15 @@ class WeatherResponsePreviewParameter : PreviewParameterProvider<WeatherDetail> 
             dummy,
             dummy.copy(
                 weather = Weather.Cloudy,
-                area = "大阪",
+                areaName = "Osaka",
             ),
             dummy.copy(
                 weather = Weather.Rainy,
-                area = "名古屋",
+                areaName = "Fukuoka",
             ),
             dummy.copy(
                 weather = Weather.Snowy,
-                area = "札幌",
+                areaName = "Sapporo",
             ),
         )
 
@@ -30,7 +31,8 @@ class WeatherResponsePreviewParameter : PreviewParameterProvider<WeatherDetail> 
             maxTemp = 30.0,
             minTemp = 20.0,
             date = Instant.parse("2022-01-01T00:00:00Z"),
-            area = "東京",
+            area = Area.TOKYO,
+            areaName = "Tokyo",
         )
     }
 }

--- a/core/ui/src/main/java/jp/co/yumemi/droidtraining/core/ui/previews/WeatherResponsePreviewParameter.kt
+++ b/core/ui/src/main/java/jp/co/yumemi/droidtraining/core/ui/previews/WeatherResponsePreviewParameter.kt
@@ -27,8 +27,8 @@ class WeatherResponsePreviewParameter : PreviewParameterProvider<WeatherDetail> 
     companion object {
         val dummy = WeatherDetail(
             weather = Weather.Sunny,
-            maxTemp = 30,
-            minTemp = 20,
+            maxTemp = 30.0,
+            minTemp = 20.0,
             date = Instant.parse("2022-01-01T00:00:00Z"),
             area = "東京",
         )

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=false
+
+android.defaults.buildfeatures.buildconfig=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,9 @@ koinAnnotations = "1.4.0-RC3"
 # Moshi
 moshi = "1.13.0"
 
+# Ktor
+ktor = "2.3.12"
+
 # Testing
 junit = "4.13.2"
 truth = "1.1.5"
@@ -113,6 +116,13 @@ koin-ksp-compiler = { module = "io.insert-koin:koin-ksp-compiler", version.ref =
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 
+# Ktor
+ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
+ktor-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktot-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+
 # Testing
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
@@ -152,4 +162,12 @@ koin = [
     "koin-compose",
     "koin-android",
     "koin-annotations",
+]
+
+ktor = [
+    "ktor-core",
+    "ktor-android",
+    "ktor-content-negotiation",
+    "ktor-serialization-json",
+    "ktot-logging",
 ]


### PR DESCRIPTION
## 修正内容
- closes #22 
- OpenWeatherMap API とつなぎ込みを行いました
  - `YumemiWeatherSource` という新規 DataSource を作成しました
  - 通信は Ktor、デコーダーは kotlinx-serialization を用います
  - API KEY が必要なため、`local.properties` に `OPEN_WEATHER_MAP_API_KEY` という値を作成してください



## レビューレベルの設定
<!--
希望するレビューレベルにチェックをつけてください。[x]のように小文字エックスを入れるとチェックがつきます。
-->

- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [ ] ぱっとみて違和感がないかチェックしてApproveする
- [x] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点
- 通信して正しい値をUIに反映できているか
- DummyWeatherSource が不要になりますが、この削除は別 PR で行います


## スクリーンショット
| After |
| - |
|<video src="https://github.com/user-attachments/assets/17516189-d702-4d33-a6af-72a1e5bec640" >|

## 備考
- N/A
