### PR TITLE
Add compose UI test for MainScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+
 import com.android.build.api.variant.BuildConfigField
 import org.jetbrains.kotlin.konan.properties.Properties
 import java.io.Serializable
@@ -22,6 +23,13 @@ android {
             it.buildConfigFields.putBuildConfig(localProperties, "OPEN_WEATHER_MAP_API_KEY")
         }
     }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/LICENSE.md"
+            excludes += "/META-INF/LICENSE-notice.md"
+        }
+    }
 }
 
 dependencies {
@@ -33,6 +41,10 @@ dependencies {
 
     implementation(libs.bundles.ui.implementations)
     implementation(libs.compose.constraint.layout)
+
+    androidTestImplementation(platform(libs.koin.bom))
+    androidTestImplementation(platform(libs.compose.bom))
+    androidTestImplementation(libs.bundles.android.testing)
 }
 
 fun MapProperty<String, BuildConfigField<out Serializable>>.putBuildConfig(

--- a/app/src/androidTest/java/jp/co/yumemi/droidtraining/MainScreenTest.kt
+++ b/app/src/androidTest/java/jp/co/yumemi/droidtraining/MainScreenTest.kt
@@ -1,0 +1,136 @@
+package jp.co.yumemi.droidtraining
+
+import android.app.Application
+import android.content.Context
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import io.mockk.coEvery
+import io.mockk.mockk
+import jp.co.yumemi.droidtraining.components.MainScreen
+import jp.co.yumemi.droidtraining.core.model.Area
+import jp.co.yumemi.droidtraining.core.model.Weather
+import jp.co.yumemi.droidtraining.core.model.WeatherDetail
+import jp.co.yumemi.droidtraining.core.repository.YumemiWeatherRepository
+import jp.co.yumemi.droidtraining.di.applyModules
+import kotlinx.datetime.Instant
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.startKoin
+import org.koin.test.KoinTest
+
+class MainScreenTest : KoinTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val weatherRepository = mockk<YumemiWeatherRepository>()
+    private val viewModel = MainViewModel(weatherRepository)
+
+    private val instrumentationContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val application = instrumentationContext.applicationContext as Application
+
+    private val dummyWeatherDetail1 = WeatherDetail(
+        area = Area.TOKYO,
+        areaName = "Tokyo",
+        weather = Weather.Cloudy,
+        maxTemp = 36.8,
+        minTemp = 21.2,
+        date = Instant.parse("2022-01-01T00:00:00Z"),
+    )
+
+    private val dummyWeatherDetail2 = WeatherDetail(
+        area = Area.NAGOYA,
+        areaName = "Nagoya",
+        weather = Weather.Sunny,
+        maxTemp = 30.0,
+        minTemp = 15.0,
+        date = Instant.parse("2022-01-01T00:00:00Z"),
+    )
+
+    @Before
+    fun setup() {
+        if (GlobalContext.getOrNull() == null) {
+            startKoin {
+                androidLogger()
+                androidContext(application)
+                applyModules()
+            }
+        }
+    }
+
+    @Test
+    fun testWeatherStateUpdateDisplaysNewStateOnSuccess() {
+        // Arrange
+        coEvery { weatherRepository.fetchWeather(dummyWeatherDetail1.area) } returns dummyWeatherDetail1
+        coEvery { weatherRepository.fetchWeather(dummyWeatherDetail2.area) } returns dummyWeatherDetail2
+
+        composeRule.setContent {
+            MainScreen(
+                modifier = Modifier.fillMaxSize(),
+                viewModel = viewModel,
+            )
+        }
+
+        // Verify the initial state
+        composeRule.onNodeWithTag("area_name").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("min_temp").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("max_temp").assertIsNotDisplayed()
+
+        // Trigger the reload
+        composeRule.onNodeWithTag("reload_button").performClick()
+
+        // Verify the updated state
+        composeRule.onNodeWithTag("area_name").assertTextEquals(dummyWeatherDetail1.areaName)
+        composeRule.onNodeWithTag("min_temp").assertTextEquals("%.2f℃".format(dummyWeatherDetail1.minTemp))
+        composeRule.onNodeWithTag("max_temp").assertTextEquals("%.2f℃".format(dummyWeatherDetail1.maxTemp))
+
+        // Trigger the next
+        composeRule.onNodeWithTag("next_button").performClick()
+
+        // Verify the updated state
+        composeRule.onNodeWithTag("area_name").assertTextEquals(dummyWeatherDetail2.areaName)
+        composeRule.onNodeWithTag("min_temp").assertTextEquals("%.2f℃".format(dummyWeatherDetail2.minTemp))
+        composeRule.onNodeWithTag("max_temp").assertTextEquals("%.2f℃".format(dummyWeatherDetail2.maxTemp))
+    }
+
+    @Test
+    fun testWeatherStateUpdateShowsErrorDialogOnFailure() {
+        // Arrange
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val errorTitle = context.getString(R.string.error_title_common)
+        val errorMessage = context.getString(R.string.error_message_common)
+
+        coEvery { weatherRepository.fetchWeather(dummyWeatherDetail1.area) } throws Exception()
+
+        composeRule.setContent {
+            MainScreen(
+                modifier = Modifier.fillMaxSize(),
+                viewModel = viewModel,
+            )
+        }
+
+        // Verify the initial state
+        composeRule.onNodeWithTag("area_name").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("min_temp").assertIsNotDisplayed()
+        composeRule.onNodeWithTag("max_temp").assertIsNotDisplayed()
+
+        // Trigger the reload
+        composeRule.onNodeWithTag("reload_button").performClick()
+
+        // Verify the error dialog is displayed
+        composeRule.onNodeWithText(errorTitle).assertIsDisplayed()
+        composeRule.onNodeWithText(errorMessage).assertIsDisplayed()
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-    </application>
 
+        <activity android:name="androidx.activity.ComponentActivity" />
+    </application>
 </manifest>

--- a/app/src/main/java/jp/co/yumemi/droidtraining/MainActivity.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/MainActivity.kt
@@ -8,18 +8,13 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import jp.co.yumemi.droidtraining.components.MainScreen
 import jp.co.yumemi.droidtraining.core.model.ThemeConfig
 import jp.co.yumemi.droidtraining.core.ui.YumemiTheme
 import jp.co.yumemi.droidtraining.core.ui.shouldUseDarkTheme
-import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MainActivity : AppCompatActivity() {
-
-    private val viewModel by viewModel<MainViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,9 +25,6 @@ class MainActivity : AppCompatActivity() {
 
             val lightScrim = Color.argb(0xe6, 0xFF, 0xFF, 0xFF)
             val darkScrim = Color.argb(0x80, 0x1b, 0x1b, 0x1b)
-
-            val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-            val screenState by viewModel.screenState.collectAsStateWithLifecycle()
 
             // LaunchedEffect は Dispatch が必要なので、起動時は DisposableEffect の方が若干早く実行される（らしい）
             // FYI: https://github.com/android/nowinandroid/pull/330/files#r999831539
@@ -50,11 +42,6 @@ class MainActivity : AppCompatActivity() {
             ) {
                 MainScreen(
                     modifier = Modifier.fillMaxSize(),
-                    uiState = uiState,
-                    screenState = screenState,
-                    onResetViewEvent = viewModel::resetScreenState,
-                    onClickReload = viewModel::reloadWeather,
-                    onClickNext = viewModel::nextWeather,
                 )
             }
         }

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/MainActionButtonsSection.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/MainActionButtonsSection.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -28,13 +29,17 @@ internal fun MainActionButtonsSection(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         MainActionButton(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .testTag("reload_button")
+                .weight(1f),
             text = stringResource(R.string.main_weather_action_reload),
             onClick = onClickReload,
         )
 
         MainActionButton(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .testTag("next_button")
+                .weight(1f),
             text = stringResource(R.string.main_weather_action_next),
             onClick = onClickNext,
         )

--- a/app/src/main/java/jp/co/yumemi/droidtraining/components/MainWeatherInfoSection.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/components/MainWeatherInfoSection.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -41,7 +42,9 @@ internal fun MainWeatherInfoSection(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Text(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .testTag("area_name")
+                .fillMaxWidth(),
             text = weather.areaName,
             style = MaterialTheme.typography.titleMedium.bold().center(),
             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -50,6 +53,7 @@ internal fun MainWeatherInfoSection(
         if (weatherIcon != null) {
             Image(
                 modifier = Modifier
+                    .testTag("weather_icon")
                     .fillMaxWidth()
                     .aspectRatio(1f),
                 painter = painterResource(weatherIcon),
@@ -59,14 +63,18 @@ internal fun MainWeatherInfoSection(
 
         Row {
             Text(
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .testTag("min_temp")
+                    .weight(1f),
                 text = "%.2f℃".format(weather.minTemp),
                 style = MaterialTheme.typography.bodyMedium.center(),
                 color = Color.Blue,
             )
 
             Text(
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .testTag("max_temp")
+                    .weight(1f),
                 text = "%.2f℃".format(weather.maxTemp),
                 style = MaterialTheme.typography.bodyMedium.center(),
                 color = Color.Red,

--- a/build-logic/src/main/java/jp/co/yumemi/droidtraining/AndroidGradleDsl.kt
+++ b/build-logic/src/main/java/jp/co/yumemi/droidtraining/AndroidGradleDsl.kt
@@ -42,6 +42,7 @@ fun Project.setupAndroid() {
 
         testOptions {
             unitTests.isIncludeAndroidResources = true
+            packagingOptions.jniLibs.useLegacyPackaging = true
             unitTests.all {
                 it.useJUnitPlatform()
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ androidxCore = "1.13.1"
 androidxAppCompat = "1.7.0"
 androidxActivity = "1.9.1"
 androidxLifecycle = "2.8.4"
-androidxCompose = "2024.06.00"
+androidxCompose = "2024.08.00"
 androidxComposeConstraintLayout = "1.0.1"
 
 # Google
@@ -40,6 +40,8 @@ moshi = "1.13.0"
 ktor = "2.3.12"
 
 # Testing
+androidXJunit = "1.1.5"
+androidxEspresso = "3.5.1"
 kotest = "5.9.0"
 kotestKoin = "1.3.0"
 mockk = "1.13.11"
@@ -109,6 +111,7 @@ koin-compose = { module = "io.insert-koin:koin-androidx-compose" }
 koin-annotations = { module = "io.insert-koin:koin-annotations", version.ref = "koinAnnotations" }
 koin-ksp-compiler = { module = "io.insert-koin:koin-ksp-compiler", version.ref = "koinAnnotations" }
 koin-test = { module = "io.insert-koin:koin-test" }
+koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4" }
 
 # Moshi
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
@@ -128,6 +131,10 @@ kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest"
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-extensions-koin = { module = "io.kotest.extensions:kotest-extensions-koin", version.ref = "kotestKoin" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
+androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidXJunit" }
+androidx-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxEspresso" }
+androidx-compose-test = { module = "androidx.compose.ui:ui-test-junit4" }
 
 # Other
 twitter-compose-rule = { module = "com.twitter.compose.rules:detekt", version.ref = "twitterComposeRule" }
@@ -179,4 +186,13 @@ testing = [
     "kotest-assertions-core",
     "kotest-extensions-koin",
     "mockk",
+]
+
+android-testing = [
+    "koin-test",
+    "koin-test-junit4",
+    "androidx-junit",
+    "androidx-espresso",
+    "androidx-compose-test",
+    "mockk-android",
 ]


### PR DESCRIPTION
#51 の続きです

## 修正内容
- closes #26 
- JUnit と mockk で UI テストを記述します
- issue に書かれていた、以下の二つのパターンをテストしています
  - 天気状態の更新に成功したら新しい状態が画面に表示されるのを確認
  - 天気状態の更新に失敗したらエラーダイアログが表示されるのを確認


## レビューレベルの設定
<!--
希望するレビューレベルにチェックをつけてください。[x]のように小文字エックスを入れるとチェックがつきます。
-->

- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [x] ぱっとみて違和感がないかチェックしてApproveする
- [ ] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点
- テストが通るか
- Firebase Test Lab などを使って UI テストを CI に組み込もうかと思いましたが、メンターの方々が見れるように...などと考えると複雑になるので今回は実施していません


## スクリーンショット
- N/A

## 備考
- N/A
