### PR TITLE
Add logging interceptor

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -20,9 +20,14 @@
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/api" />
             <option value="$PROJECT_DIR$/app" />
             <option value="$PROJECT_DIR$/build-logic" />
+            <option value="$PROJECT_DIR$/core" />
+            <option value="$PROJECT_DIR$/core/common" />
+            <option value="$PROJECT_DIR$/core/datasource" />
+            <option value="$PROJECT_DIR$/core/model" />
+            <option value="$PROJECT_DIR$/core/repository" />
+            <option value="$PROJECT_DIR$/core/ui" />
           </set>
         </option>
         <option name="resolveExternalAnnotations" value="false" />

--- a/app/src/main/java/jp/co/yumemi/droidtraining/YumemiApplication.kt
+++ b/app/src/main/java/jp/co/yumemi/droidtraining/YumemiApplication.kt
@@ -1,15 +1,19 @@
 package jp.co.yumemi.droidtraining
 
 import android.app.Application
+import jp.co.yumemi.droidtraining.core.common.YumemiDebugTree
 import jp.co.yumemi.droidtraining.di.applyModules
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
+import timber.log.Timber
 
 class YumemiApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        Timber.plant(YumemiDebugTree())
 
         startKoin {
             androidContext(this@YumemiApplication)

--- a/core/common/src/main/java/jp/co/yumemi/droidtraining/core/common/YumemiDebugTree.kt
+++ b/core/common/src/main/java/jp/co/yumemi/droidtraining/core/common/YumemiDebugTree.kt
@@ -1,0 +1,31 @@
+package jp.co.yumemi.droidtraining.core.common
+
+import android.util.Log
+import timber.log.Timber
+import java.util.Locale
+
+class YumemiDebugTree : Timber.DebugTree() {
+
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        Log.println(priority, "AndroidTraining", "$message: ${getCallerInfo()}")
+    }
+
+    private fun getCallerInfo(): String {
+        val stackTrace = Throwable().stackTrace
+
+        if (stackTrace.size < 6) {
+            // stack[0] YumemiDebugTree.getCallerInfo()
+            // stack[1] YumemiDebugTree.log()
+            // stack[2] Tree.prepareLog()
+            // stack[3] Tree.d()
+            // stack[4] Forrest.d()
+            // stack[5] Timber.d()
+
+            return ""
+        }
+
+        val element = stackTrace[5]
+
+        return String.format(Locale.getDefault(), "%s(%s:%s)", element.methodName, element.fileName, element.lineNumber)
+    }
+}

--- a/core/common/src/main/java/jp/co/yumemi/droidtraining/core/common/YumemiDebugTree.kt
+++ b/core/common/src/main/java/jp/co/yumemi/droidtraining/core/common/YumemiDebugTree.kt
@@ -10,6 +10,7 @@ class YumemiDebugTree : Timber.DebugTree() {
         Log.println(priority, "AndroidTraining", "$message: ${getCallerInfo()}")
     }
 
+    @Suppress("ThrowingExceptionsWithoutMessageOrCause")
     private fun getCallerInfo(): String {
         val stackTrace = Throwable().stackTrace
 

--- a/core/datasource/src/main/java/jp/co/yumemi/droidtraining/core/datasource/di/DataSourceModule.kt
+++ b/core/datasource/src/main/java/jp/co/yumemi/droidtraining/core/datasource/di/DataSourceModule.kt
@@ -3,12 +3,16 @@ package jp.co.yumemi.droidtraining.core.datasource.di
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
+import timber.log.Timber
 
 @Module
 @Named("DataSourceModule")
@@ -27,6 +31,15 @@ class DataSourceModule {
 
     @Single
     fun provideHttpClient() = HttpClient {
+        install(Logging) {
+            level = LogLevel.INFO
+            logger = object : Logger {
+                override fun log(message: String) {
+                    Timber.d(message)
+                }
+            }
+        }
+
         install(ContentNegotiation) {
             json(provideJsonFormatter())
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ ktor = "2.3.12"
 mockk = "1.13.7"
 
 # Other
+timber = "5.0.1"
 detekt = "1.23.6"
 twitterComposeRule = "0.0.26"
 kover = "0.8.3"
@@ -122,6 +123,7 @@ ktot-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 # Other
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 twitter-compose-rule = { module = "com.twitter.compose.rules:detekt", version.ref = "twitterComposeRule" }
 
 [bundles]
@@ -129,6 +131,7 @@ infra-api = [
     "kotlin-stdlib",
     "kotlinx-serialization",
     "kotlinx-datetime",
+    "timber",
 ]
 
 ui-implementations = [


### PR DESCRIPTION
## 修正内容
- closes #23 
- HTTP通信のログをインターセプターを用いて出力します
- ロギングライブラリには `Timber` を用います
- `defaultRequest` を用いてデフォルトパラメータの設定を行おうと思いましたが、以下のバグが発生しているらしくうまく動作しなかったので見送ります
  - https://youtrack.jetbrains.com/issue/KTOR-4252



## レビューレベルの設定
<!--
希望するレビューレベルにチェックをつけてください。[x]のように小文字エックスを入れるとチェックがつきます。
-->

- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [x] ぱっとみて違和感がないかチェックしてApproveする
- [ ] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点
- ログが出力されるか
- コード行が出力されるか



## スクリーンショット
- N/A

## 備考
<!--
* マージ先のブランチの設定が正しいか確認してください。
* 動画を添付するときは、GitHubの制限のため、アニメーションGifに変換してください。
-->
- N/A
