### PR TITLE
Add datasource and repository test for details api

### DIFF
--- a/core/datasource/src/test/java/jp/co/yumemi/droidtraining/core/datasource/YumemiWeatherSourceTest.kt
+++ b/core/datasource/src/test/java/jp/co/yumemi/droidtraining/core/datasource/YumemiWeatherSourceTest.kt
@@ -34,6 +34,19 @@ class YumemiWeatherSourceTest : FunSpec(), KoinTest {
             // Assert
             result shouldBe get<Json>().decodeFromString(response)
         }
+
+        test("fetchWeatherForecast should return expected WeatherForecastEntity") {
+            // Arrange
+            val response = loadResource("dummy_weather_forecast.json")
+            val client = setupMockClient(response)
+            val source = YumemiWeatherSource(client, YumemiConfig(""))
+
+            // Act
+            val result = source.fetchWeatherForecast(Area.TOKYO)
+
+            // Assert
+            result shouldBe get<Json>().decodeFromString(response)
+        }
     }
 
     override fun extensions() = listOf(KoinExtension(DataSourceModule().module))

--- a/core/datasource/src/test/resources/dummy_weather_forecast.json
+++ b/core/datasource/src/test/resources/dummy_weather_forecast.json
@@ -1,0 +1,1520 @@
+{
+  "cod": "200",
+  "message": 0,
+  "cnt": 40,
+  "list": [
+    {
+      "dt": 1724403600,
+      "main": {
+        "temp": 30.76,
+        "feels_like": 37.55,
+        "temp_min": 29.26,
+        "temp_max": 30.76,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1006,
+        "humidity": 72,
+        "temp_kf": 1.5
+      },
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "曇りがち",
+          "icon": "04d"
+        }
+      ],
+      "clouds": {
+        "all": 52
+      },
+      "wind": {
+        "speed": 7.76,
+        "deg": 174,
+        "gust": 8.65
+      },
+      "visibility": 10000,
+      "pop": 0.04,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-23 09:00:00"
+    },
+    {
+      "dt": 1724414400,
+      "main": {
+        "temp": 29.6,
+        "feels_like": 35.23,
+        "temp_min": 28.65,
+        "temp_max": 29.6,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1007,
+        "humidity": 75,
+        "temp_kf": 0.95
+      },
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "曇りがち",
+          "icon": "04n"
+        }
+      ],
+      "clouds": {
+        "all": 71
+      },
+      "wind": {
+        "speed": 7.34,
+        "deg": 175,
+        "gust": 8.91
+      },
+      "visibility": 10000,
+      "pop": 0.02,
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-23 12:00:00"
+    },
+    {
+      "dt": 1724425200,
+      "main": {
+        "temp": 28.22,
+        "feels_like": 32.16,
+        "temp_min": 28.22,
+        "temp_max": 28.22,
+        "pressure": 1012,
+        "sea_level": 1012,
+        "grnd_level": 1007,
+        "humidity": 77,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "厚い雲",
+          "icon": "04n"
+        }
+      ],
+      "clouds": {
+        "all": 90
+      },
+      "wind": {
+        "speed": 6.72,
+        "deg": 192,
+        "gust": 8.56
+      },
+      "visibility": 10000,
+      "pop": 0.15,
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-23 15:00:00"
+    },
+    {
+      "dt": 1724436000,
+      "main": {
+        "temp": 28.07,
+        "feels_like": 31.81,
+        "temp_min": 28.07,
+        "temp_max": 28.07,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1006,
+        "humidity": 77,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "厚い雲",
+          "icon": "04n"
+        }
+      ],
+      "clouds": {
+        "all": 95
+      },
+      "wind": {
+        "speed": 5.02,
+        "deg": 206,
+        "gust": 6.46
+      },
+      "visibility": 10000,
+      "pop": 0.14,
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-23 18:00:00"
+    },
+    {
+      "dt": 1724446800,
+      "main": {
+        "temp": 28.15,
+        "feels_like": 32,
+        "temp_min": 28.15,
+        "temp_max": 28.15,
+        "pressure": 1012,
+        "sea_level": 1012,
+        "grnd_level": 1007,
+        "humidity": 77,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "厚い雲",
+          "icon": "04d"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 2.92,
+        "deg": 215,
+        "gust": 4.04
+      },
+      "visibility": 10000,
+      "pop": 0.07,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-23 21:00:00"
+    },
+    {
+      "dt": 1724457600,
+      "main": {
+        "temp": 30.1,
+        "feels_like": 35.04,
+        "temp_min": 30.1,
+        "temp_max": 30.1,
+        "pressure": 1012,
+        "sea_level": 1012,
+        "grnd_level": 1008,
+        "humidity": 69,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "厚い雲",
+          "icon": "04d"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 1.97,
+        "deg": 205,
+        "gust": 2.41
+      },
+      "visibility": 10000,
+      "pop": 0,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-24 00:00:00"
+    },
+    {
+      "dt": 1724468400,
+      "main": {
+        "temp": 31.47,
+        "feels_like": 36.71,
+        "temp_min": 31.47,
+        "temp_max": 31.47,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1007,
+        "humidity": 63,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 5.62,
+        "deg": 177,
+        "gust": 4.98
+      },
+      "visibility": 10000,
+      "pop": 0.36,
+      "rain": {
+        "3h": 0.92
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-24 03:00:00"
+    },
+    {
+      "dt": 1724479200,
+      "main": {
+        "temp": 31.58,
+        "feels_like": 36.39,
+        "temp_min": 31.58,
+        "temp_max": 31.58,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1006,
+        "humidity": 61,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 98
+      },
+      "wind": {
+        "speed": 7.2,
+        "deg": 180,
+        "gust": 6.67
+      },
+      "visibility": 10000,
+      "pop": 0.44,
+      "rain": {
+        "3h": 0.1
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-24 06:00:00"
+    },
+    {
+      "dt": 1724490000,
+      "main": {
+        "temp": 29.75,
+        "feels_like": 34.21,
+        "temp_min": 29.75,
+        "temp_max": 29.75,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1006,
+        "humidity": 69,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "曇りがち",
+          "icon": "04d"
+        }
+      ],
+      "clouds": {
+        "all": 68
+      },
+      "wind": {
+        "speed": 6.47,
+        "deg": 174,
+        "gust": 6.93
+      },
+      "visibility": 10000,
+      "pop": 0.42,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-24 09:00:00"
+    },
+    {
+      "dt": 1724500800,
+      "main": {
+        "temp": 28.75,
+        "feels_like": 32.72,
+        "temp_min": 28.75,
+        "temp_max": 28.75,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1007,
+        "humidity": 73,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10n"
+        }
+      ],
+      "clouds": {
+        "all": 77
+      },
+      "wind": {
+        "speed": 5.98,
+        "deg": 179,
+        "gust": 7.27
+      },
+      "visibility": 10000,
+      "pop": 0.47,
+      "rain": {
+        "3h": 0.2
+      },
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-24 12:00:00"
+    },
+    {
+      "dt": 1724511600,
+      "main": {
+        "temp": 28.15,
+        "feels_like": 31.84,
+        "temp_min": 28.15,
+        "temp_max": 28.15,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1006,
+        "humidity": 76,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "厚い雲",
+          "icon": "04n"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 6.25,
+        "deg": 189,
+        "gust": 7.48
+      },
+      "visibility": 10000,
+      "pop": 0.29,
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-24 15:00:00"
+    },
+    {
+      "dt": 1724522400,
+      "main": {
+        "temp": 27.83,
+        "feels_like": 31.12,
+        "temp_min": 27.83,
+        "temp_max": 27.83,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1005,
+        "humidity": 76,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 804,
+          "main": "Clouds",
+          "description": "厚い雲",
+          "icon": "04n"
+        }
+      ],
+      "clouds": {
+        "all": 87
+      },
+      "wind": {
+        "speed": 4.15,
+        "deg": 197,
+        "gust": 5.03
+      },
+      "visibility": 10000,
+      "pop": 0.25,
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-24 18:00:00"
+    },
+    {
+      "dt": 1724533200,
+      "main": {
+        "temp": 27.7,
+        "feels_like": 30.96,
+        "temp_min": 27.7,
+        "temp_max": 27.7,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1006,
+        "humidity": 77,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "雲",
+          "icon": "03d"
+        }
+      ],
+      "clouds": {
+        "all": 34
+      },
+      "wind": {
+        "speed": 4.16,
+        "deg": 197,
+        "gust": 4.73
+      },
+      "visibility": 10000,
+      "pop": 0.13,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-24 21:00:00"
+    },
+    {
+      "dt": 1724544000,
+      "main": {
+        "temp": 29.9,
+        "feels_like": 33.45,
+        "temp_min": 29.9,
+        "temp_max": 29.9,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1006,
+        "humidity": 64,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 39
+      },
+      "wind": {
+        "speed": 5.02,
+        "deg": 191,
+        "gust": 5.48
+      },
+      "visibility": 10000,
+      "pop": 0.32,
+      "rain": {
+        "3h": 0.27
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-25 00:00:00"
+    },
+    {
+      "dt": 1724554800,
+      "main": {
+        "temp": 31.85,
+        "feels_like": 35.6,
+        "temp_min": 31.85,
+        "temp_max": 31.85,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1005,
+        "humidity": 56,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 801,
+          "main": "Clouds",
+          "description": "薄い雲",
+          "icon": "02d"
+        }
+      ],
+      "clouds": {
+        "all": 22
+      },
+      "wind": {
+        "speed": 6.82,
+        "deg": 177,
+        "gust": 6.57
+      },
+      "visibility": 10000,
+      "pop": 0.32,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-25 03:00:00"
+    },
+    {
+      "dt": 1724565600,
+      "main": {
+        "temp": 31.6,
+        "feels_like": 35.34,
+        "temp_min": 31.6,
+        "temp_max": 31.6,
+        "pressure": 1009,
+        "sea_level": 1009,
+        "grnd_level": 1004,
+        "humidity": 57,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 801,
+          "main": "Clouds",
+          "description": "薄い雲",
+          "icon": "02d"
+        }
+      ],
+      "clouds": {
+        "all": 18
+      },
+      "wind": {
+        "speed": 8.26,
+        "deg": 182,
+        "gust": 8.29
+      },
+      "visibility": 10000,
+      "pop": 0.33,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-25 06:00:00"
+    },
+    {
+      "dt": 1724576400,
+      "main": {
+        "temp": 29.1,
+        "feels_like": 32.76,
+        "temp_min": 29.1,
+        "temp_max": 29.1,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1005,
+        "humidity": 69,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 801,
+          "main": "Clouds",
+          "description": "薄い雲",
+          "icon": "02d"
+        }
+      ],
+      "clouds": {
+        "all": 13
+      },
+      "wind": {
+        "speed": 8.34,
+        "deg": 179,
+        "gust": 9.31
+      },
+      "visibility": 10000,
+      "pop": 0.27,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-25 09:00:00"
+    },
+    {
+      "dt": 1724587200,
+      "main": {
+        "temp": 27.91,
+        "feels_like": 31.02,
+        "temp_min": 27.91,
+        "temp_max": 27.91,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1006,
+        "humidity": 74,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 801,
+          "main": "Clouds",
+          "description": "薄い雲",
+          "icon": "02n"
+        }
+      ],
+      "clouds": {
+        "all": 13
+      },
+      "wind": {
+        "speed": 7.07,
+        "deg": 179,
+        "gust": 8.75
+      },
+      "visibility": 10000,
+      "pop": 0.2,
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-25 12:00:00"
+    },
+    {
+      "dt": 1724598000,
+      "main": {
+        "temp": 27.13,
+        "feels_like": 29.63,
+        "temp_min": 27.13,
+        "temp_max": 27.13,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1006,
+        "humidity": 76,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 801,
+          "main": "Clouds",
+          "description": "薄い雲",
+          "icon": "02n"
+        }
+      ],
+      "clouds": {
+        "all": 17
+      },
+      "wind": {
+        "speed": 6.25,
+        "deg": 176,
+        "gust": 7.85
+      },
+      "visibility": 10000,
+      "pop": 0.14,
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-25 15:00:00"
+    },
+    {
+      "dt": 1724608800,
+      "main": {
+        "temp": 26.91,
+        "feels_like": 29.11,
+        "temp_min": 26.91,
+        "temp_max": 26.91,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1005,
+        "humidity": 75,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "雲",
+          "icon": "03n"
+        }
+      ],
+      "clouds": {
+        "all": 34
+      },
+      "wind": {
+        "speed": 4.97,
+        "deg": 178,
+        "gust": 6.55
+      },
+      "visibility": 10000,
+      "pop": 0.1,
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-25 18:00:00"
+    },
+    {
+      "dt": 1724619600,
+      "main": {
+        "temp": 26.87,
+        "feels_like": 29.03,
+        "temp_min": 26.87,
+        "temp_max": 26.87,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1006,
+        "humidity": 75,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "曇りがち",
+          "icon": "04d"
+        }
+      ],
+      "clouds": {
+        "all": 56
+      },
+      "wind": {
+        "speed": 2.99,
+        "deg": 176,
+        "gust": 4.13
+      },
+      "visibility": 10000,
+      "pop": 0.07,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-25 21:00:00"
+    },
+    {
+      "dt": 1724630400,
+      "main": {
+        "temp": 28.89,
+        "feels_like": 31.15,
+        "temp_min": 28.89,
+        "temp_max": 28.89,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1006,
+        "humidity": 62,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "曇りがち",
+          "icon": "04d"
+        }
+      ],
+      "clouds": {
+        "all": 77
+      },
+      "wind": {
+        "speed": 3.31,
+        "deg": 163,
+        "gust": 3.83
+      },
+      "visibility": 10000,
+      "pop": 0.21,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-26 00:00:00"
+    },
+    {
+      "dt": 1724641200,
+      "main": {
+        "temp": 30.84,
+        "feels_like": 33.37,
+        "temp_min": 30.84,
+        "temp_max": 30.84,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1005,
+        "humidity": 55,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 88
+      },
+      "wind": {
+        "speed": 4.8,
+        "deg": 166,
+        "gust": 5
+      },
+      "visibility": 10000,
+      "pop": 0.53,
+      "rain": {
+        "3h": 0.15
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-26 03:00:00"
+    },
+    {
+      "dt": 1724652000,
+      "main": {
+        "temp": 31.2,
+        "feels_like": 33.82,
+        "temp_min": 31.2,
+        "temp_max": 31.2,
+        "pressure": 1009,
+        "sea_level": 1009,
+        "grnd_level": 1004,
+        "humidity": 54,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 86
+      },
+      "wind": {
+        "speed": 6.09,
+        "deg": 173,
+        "gust": 6.69
+      },
+      "visibility": 10000,
+      "pop": 0.59,
+      "rain": {
+        "3h": 0.17
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-26 06:00:00"
+    },
+    {
+      "dt": 1724662800,
+      "main": {
+        "temp": 29.66,
+        "feels_like": 32.38,
+        "temp_min": 29.66,
+        "temp_max": 29.66,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1005,
+        "humidity": 61,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 803,
+          "main": "Clouds",
+          "description": "曇りがち",
+          "icon": "04d"
+        }
+      ],
+      "clouds": {
+        "all": 77
+      },
+      "wind": {
+        "speed": 6.4,
+        "deg": 167,
+        "gust": 7.3
+      },
+      "visibility": 10000,
+      "pop": 0.63,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-26 09:00:00"
+    },
+    {
+      "dt": 1724673600,
+      "main": {
+        "temp": 28.56,
+        "feels_like": 31.16,
+        "temp_min": 28.56,
+        "temp_max": 28.56,
+        "pressure": 1011,
+        "sea_level": 1011,
+        "grnd_level": 1006,
+        "humidity": 66,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10n"
+        }
+      ],
+      "clouds": {
+        "all": 88
+      },
+      "wind": {
+        "speed": 5.99,
+        "deg": 174,
+        "gust": 7.67
+      },
+      "visibility": 10000,
+      "pop": 0.69,
+      "rain": {
+        "3h": 0.33
+      },
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-26 12:00:00"
+    },
+    {
+      "dt": 1724684400,
+      "main": {
+        "temp": 27.49,
+        "feels_like": 29.93,
+        "temp_min": 27.49,
+        "temp_max": 27.49,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1005,
+        "humidity": 72,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10n"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 5.42,
+        "deg": 168,
+        "gust": 7.58
+      },
+      "visibility": 10000,
+      "pop": 0.7,
+      "rain": {
+        "3h": 0.71
+      },
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-26 15:00:00"
+    },
+    {
+      "dt": 1724695200,
+      "main": {
+        "temp": 27.03,
+        "feels_like": 29.16,
+        "temp_min": 27.03,
+        "temp_max": 27.03,
+        "pressure": 1009,
+        "sea_level": 1009,
+        "grnd_level": 1005,
+        "humidity": 73,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10n"
+        }
+      ],
+      "clouds": {
+        "all": 97
+      },
+      "wind": {
+        "speed": 4.49,
+        "deg": 181,
+        "gust": 6.81
+      },
+      "visibility": 10000,
+      "pop": 0.76,
+      "rain": {
+        "3h": 1.93
+      },
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-26 18:00:00"
+    },
+    {
+      "dt": 1724706000,
+      "main": {
+        "temp": 26.48,
+        "feels_like": 26.48,
+        "temp_min": 26.48,
+        "temp_max": 26.48,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1005,
+        "humidity": 76,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 501,
+          "main": "Rain",
+          "description": "適度な雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 65
+      },
+      "wind": {
+        "speed": 5.2,
+        "deg": 168,
+        "gust": 8
+      },
+      "visibility": 10000,
+      "pop": 0.86,
+      "rain": {
+        "3h": 3.05
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-26 21:00:00"
+    },
+    {
+      "dt": 1724716800,
+      "main": {
+        "temp": 28.74,
+        "feels_like": 31.83,
+        "temp_min": 28.74,
+        "temp_max": 28.74,
+        "pressure": 1010,
+        "sea_level": 1010,
+        "grnd_level": 1005,
+        "humidity": 68,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 44
+      },
+      "wind": {
+        "speed": 6.17,
+        "deg": 160,
+        "gust": 8.21
+      },
+      "visibility": 10000,
+      "pop": 0.83,
+      "rain": {
+        "3h": 2.16
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-27 00:00:00"
+    },
+    {
+      "dt": 1724727600,
+      "main": {
+        "temp": 30.88,
+        "feels_like": 33.44,
+        "temp_min": 30.88,
+        "temp_max": 30.88,
+        "pressure": 1009,
+        "sea_level": 1009,
+        "grnd_level": 1004,
+        "humidity": 55,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 36
+      },
+      "wind": {
+        "speed": 7.01,
+        "deg": 167,
+        "gust": 8.7
+      },
+      "visibility": 10000,
+      "pop": 0.45,
+      "rain": {
+        "3h": 0.27
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-27 03:00:00"
+    },
+    {
+      "dt": 1724738400,
+      "main": {
+        "temp": 30.99,
+        "feels_like": 33,
+        "temp_min": 30.99,
+        "temp_max": 30.99,
+        "pressure": 1008,
+        "sea_level": 1008,
+        "grnd_level": 1003,
+        "humidity": 52,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 802,
+          "main": "Clouds",
+          "description": "雲",
+          "icon": "03d"
+        }
+      ],
+      "clouds": {
+        "all": 37
+      },
+      "wind": {
+        "speed": 7.37,
+        "deg": 159,
+        "gust": 8.01
+      },
+      "visibility": 10000,
+      "pop": 0.34,
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-27 06:00:00"
+    },
+    {
+      "dt": 1724749200,
+      "main": {
+        "temp": 28.6,
+        "feels_like": 30.94,
+        "temp_min": 28.6,
+        "temp_max": 28.6,
+        "pressure": 1008,
+        "sea_level": 1008,
+        "grnd_level": 1003,
+        "humidity": 64,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 25
+      },
+      "wind": {
+        "speed": 6.28,
+        "deg": 144,
+        "gust": 6.66
+      },
+      "visibility": 10000,
+      "pop": 0.3,
+      "rain": {
+        "3h": 0.17
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-27 09:00:00"
+    },
+    {
+      "dt": 1724760000,
+      "main": {
+        "temp": 27.17,
+        "feels_like": 29.15,
+        "temp_min": 27.17,
+        "temp_max": 27.17,
+        "pressure": 1008,
+        "sea_level": 1008,
+        "grnd_level": 1003,
+        "humidity": 70,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10n"
+        }
+      ],
+      "clouds": {
+        "all": 53
+      },
+      "wind": {
+        "speed": 4.65,
+        "deg": 118,
+        "gust": 6.41
+      },
+      "visibility": 10000,
+      "pop": 0.48,
+      "rain": {
+        "3h": 0.65
+      },
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-27 12:00:00"
+    },
+    {
+      "dt": 1724770800,
+      "main": {
+        "temp": 26.46,
+        "feels_like": 26.46,
+        "temp_min": 26.46,
+        "temp_max": 26.46,
+        "pressure": 1007,
+        "sea_level": 1007,
+        "grnd_level": 1002,
+        "humidity": 75,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 500,
+          "main": "Rain",
+          "description": "小雨",
+          "icon": "10n"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 3.64,
+        "deg": 122,
+        "gust": 5.89
+      },
+      "visibility": 10000,
+      "pop": 0.68,
+      "rain": {
+        "3h": 1.44
+      },
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-27 15:00:00"
+    },
+    {
+      "dt": 1724781600,
+      "main": {
+        "temp": 26.07,
+        "feels_like": 26.07,
+        "temp_min": 26.07,
+        "temp_max": 26.07,
+        "pressure": 1005,
+        "sea_level": 1005,
+        "grnd_level": 1000,
+        "humidity": 78,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 501,
+          "main": "Rain",
+          "description": "適度な雨",
+          "icon": "10n"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 4.41,
+        "deg": 145,
+        "gust": 6.97
+      },
+      "visibility": 8370,
+      "pop": 0.95,
+      "rain": {
+        "3h": 4.25
+      },
+      "sys": {
+        "pod": "n"
+      },
+      "dt_txt": "2024-08-27 18:00:00"
+    },
+    {
+      "dt": 1724792400,
+      "main": {
+        "temp": 26.02,
+        "feels_like": 26.02,
+        "temp_min": 26.02,
+        "temp_max": 26.02,
+        "pressure": 1004,
+        "sea_level": 1004,
+        "grnd_level": 1000,
+        "humidity": 81,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 501,
+          "main": "Rain",
+          "description": "適度な雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 6.11,
+        "deg": 127,
+        "gust": 10.67
+      },
+      "visibility": 10000,
+      "pop": 0.97,
+      "rain": {
+        "3h": 6.25
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-27 21:00:00"
+    },
+    {
+      "dt": 1724803200,
+      "main": {
+        "temp": 25.81,
+        "feels_like": 26.64,
+        "temp_min": 25.81,
+        "temp_max": 25.81,
+        "pressure": 1003,
+        "sea_level": 1003,
+        "grnd_level": 999,
+        "humidity": 84,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 501,
+          "main": "Rain",
+          "description": "適度な雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 7.92,
+        "deg": 120,
+        "gust": 13.22
+      },
+      "visibility": 5576,
+      "pop": 1,
+      "rain": {
+        "3h": 8.83
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-28 00:00:00"
+    },
+    {
+      "dt": 1724814000,
+      "main": {
+        "temp": 25.71,
+        "feels_like": 26.66,
+        "temp_min": 25.71,
+        "temp_max": 25.71,
+        "pressure": 998,
+        "sea_level": 998,
+        "grnd_level": 993,
+        "humidity": 89,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 501,
+          "main": "Rain",
+          "description": "適度な雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 13.53,
+        "deg": 126,
+        "gust": 22.44
+      },
+      "visibility": 4358,
+      "pop": 1,
+      "rain": {
+        "3h": 9.63
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-28 03:00:00"
+    },
+    {
+      "dt": 1724824800,
+      "main": {
+        "temp": 25.43,
+        "feels_like": 26.4,
+        "temp_min": 25.43,
+        "temp_max": 25.43,
+        "pressure": 988,
+        "sea_level": 988,
+        "grnd_level": 983,
+        "humidity": 91,
+        "temp_kf": 0
+      },
+      "weather": [
+        {
+          "id": 502,
+          "main": "Rain",
+          "description": "強い雨",
+          "icon": "10d"
+        }
+      ],
+      "clouds": {
+        "all": 100
+      },
+      "wind": {
+        "speed": 21.45,
+        "deg": 147,
+        "gust": 32.35
+      },
+      "visibility": 2616,
+      "pop": 1,
+      "rain": {
+        "3h": 31.16
+      },
+      "sys": {
+        "pod": "d"
+      },
+      "dt_txt": "2024-08-28 06:00:00"
+    }
+  ],
+  "city": {
+    "id": 1850144,
+    "name": "東京都",
+    "coord": {
+      "lat": 35.6895,
+      "lon": 139.6917
+    },
+    "country": "JP",
+    "population": 0,
+    "timezone": 32400,
+    "sunrise": 1724357188,
+    "sunset": 1724404902
+  }
+}

--- a/core/repository/src/test/java/jp/co/yumemi/droidtraining/core/repository/YumemiWeatherRepositoryTest.kt
+++ b/core/repository/src/test/java/jp/co/yumemi/droidtraining/core/repository/YumemiWeatherRepositoryTest.kt
@@ -1,12 +1,15 @@
 package jp.co.yumemi.droidtraining.core.repository
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import jp.co.yumemi.droidtraining.core.datasource.YumemiWeatherSource
 import jp.co.yumemi.droidtraining.core.model.Area
+import jp.co.yumemi.droidtraining.core.model.WeatherForecast
 import jp.co.yumemi.droidtraining.core.model.entity.WeatherDetailEntity
+import jp.co.yumemi.droidtraining.core.model.entity.WeatherForecastEntity
 import jp.co.yumemi.droidtraining.core.repository.mapper.WeatherDetailMapper
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -17,6 +20,8 @@ class YumemiWeatherRepositoryTest : FunSpec(), KoinTest {
     private val weatherDetailMapper = mockk<WeatherDetailMapper>()
     private val weatherSource = mockk<YumemiWeatherSource>()
     private val dummyWeatherDetailEntity = mockk<WeatherDetailEntity>()
+    private val dummyWeatherForecastEntity = mockk<WeatherForecastEntity>()
+    private val dummyWeatherForecast = mockk<WeatherForecast>()
     private val testDispatcher = StandardTestDispatcher()
 
     init {
@@ -36,6 +41,41 @@ class YumemiWeatherRepositoryTest : FunSpec(), KoinTest {
             // Assert
             coVerify { weatherDetailMapper.asWeatherDetail(dummyWeatherDetailEntity) }
             coVerify { weatherSource.fetchWeather(area) }
+        }
+
+        test("fetchWeatherForecast should call datasource and mapper") {
+            // Arrange
+            val area = Area.TOKYO
+            val repository = YumemiWeatherRepositoryImpl(weatherSource, weatherDetailMapper, testDispatcher)
+
+            coEvery { weatherDetailMapper.asWeatherForecast(dummyWeatherForecastEntity) } returns mockk()
+            coEvery { weatherSource.fetchWeatherForecast(area) } returns dummyWeatherForecastEntity
+
+            // Act
+            runTest(testDispatcher) {
+                repository.fetchWeatherForecast(area)
+            }
+
+            // Assert
+            coVerify { weatherDetailMapper.asWeatherForecast(dummyWeatherForecastEntity) }
+            coVerify { weatherSource.fetchWeatherForecast(area) }
+        }
+
+        test("fetchWeatherForecast should return the same value as the mapper") {
+            // Arrange
+            val area = Area.TOKYO
+            val repository = YumemiWeatherRepositoryImpl(weatherSource, weatherDetailMapper, testDispatcher)
+
+            coEvery { weatherDetailMapper.asWeatherForecast(dummyWeatherForecastEntity) } returns dummyWeatherForecast
+            coEvery { weatherSource.fetchWeatherForecast(area) } returns dummyWeatherForecastEntity
+
+            runTest(testDispatcher) {
+                // Act
+                val result = repository.fetchWeatherForecast(area)
+
+                // Assert
+                result shouldBe dummyWeatherForecast
+            }
         }
     }
 }


### PR DESCRIPTION
#56 の続きです

## 修正内容
- #56 で追加した DataSource と Repository のメソッドのテストを追加します

## レビューレベルの設定
<!--
希望するレビューレベルにチェックをつけてください。[x]のように小文字エックスを入れるとチェックがつきます。
-->

- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [x] ぱっとみて違和感がないかチェックしてApproveする
- [ ] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点
- テストケースの漏れはないか

## スクリーンショット
- N/A

## 備考
- N/A
