### PR TITLE
Fix home landscape layout

### DIFF
--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -18,8 +18,6 @@ kotlin {
             implementation(project(":core:ui"))
             implementation(project(":core:model"))
             implementation(project(":core:common"))
-
-            implementation(libs.compose.constraint.layout)
         }
     }
 }

--- a/feature/home/src/commonMain/kotlin/jp/co/yumemi/droidtraining/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/jp/co/yumemi/droidtraining/feature/home/HomeScreen.kt
@@ -1,9 +1,11 @@
 package jp.co.yumemi.droidtraining.feature.home
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.MaterialTheme
@@ -13,8 +15,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import jp.co.yumemi.droidtraining.core.model.Area
 import jp.co.yumemi.droidtraining.core.ui.CONTAINER_MAX_WIDTH
@@ -45,53 +45,27 @@ internal fun HomeScreen(
         modifier = modifier,
         containerColor = MaterialTheme.colorScheme.surface,
     ) {
-        Box(
+        BoxWithConstraints(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
-            ConstraintLayout(
+            Column(
                 modifier = Modifier
-                    .fillMaxSize()
                     .widthIn(max = CONTAINER_MAX_WIDTH)
-                    .background(MaterialTheme.colorScheme.background)
                     .padding(it),
+                verticalArrangement = Arrangement.spacedBy(if (maxHeight > maxWidth) 80.dp else 16.dp)
             ) {
-                val (weatherInfoSection, actionButtonsSection) = createRefs()
-
                 if (uiState.weather != null) {
                     MainWeatherInfoSection(
-                        modifier = Modifier.constrainAs(weatherInfoSection) {
-                            top.linkTo(parent.top)
-                            start.linkTo(parent.start)
-                            end.linkTo(parent.end)
-                            bottom.linkTo(parent.bottom)
-
-                            width = Dimension.percent(0.5f)
-                            height = Dimension.wrapContent
-                        },
+                        modifier = Modifier
+                            .fillMaxWidth(0.5f)
+                            .weight(1f, false),
                         weather = uiState.weather!!,
                     )
                 }
 
                 MainActionButtonsSection(
-                    modifier = Modifier.constrainAs(actionButtonsSection) {
-                        if (uiState.weather != null) {
-                            top.linkTo(weatherInfoSection.bottom, 80.dp)
-                            start.linkTo(weatherInfoSection.start)
-                            end.linkTo(weatherInfoSection.end)
-
-                            width = Dimension.fillToConstraints
-                            height = Dimension.wrapContent
-                        } else {
-                            top.linkTo(parent.top)
-                            bottom.linkTo(parent.bottom)
-                            start.linkTo(parent.start)
-                            end.linkTo(parent.end)
-
-                            width = Dimension.percent(0.5f)
-                            height = Dimension.wrapContent
-                        }
-                    },
+                    modifier = Modifier.fillMaxWidth(0.5f),
                     onClickReload = viewModel::reloadWeather,
                     onClickNext = {
                         uiState.weather?.area?.let(onClickNext)

--- a/feature/home/src/commonMain/kotlin/jp/co/yumemi/droidtraining/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/jp/co/yumemi/droidtraining/feature/home/HomeScreen.kt
@@ -53,7 +53,7 @@ internal fun HomeScreen(
                 modifier = Modifier
                     .widthIn(max = CONTAINER_MAX_WIDTH)
                     .padding(it),
-                verticalArrangement = Arrangement.spacedBy(if (maxHeight > maxWidth) 80.dp else 16.dp)
+                verticalArrangement = Arrangement.spacedBy(if (maxHeight > maxWidth) 80.dp else 16.dp),
             ) {
                 if (uiState.weather != null) {
                     MainWeatherInfoSection(

--- a/feature/home/src/commonMain/kotlin/jp/co/yumemi/droidtraining/feature/home/components/MainWeatherInfoSection.kt
+++ b/feature/home/src/commonMain/kotlin/jp/co/yumemi/droidtraining/feature/home/components/MainWeatherInfoSection.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -40,6 +41,7 @@ internal fun MainWeatherInfoSection(
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             modifier = Modifier
@@ -54,7 +56,7 @@ internal fun MainWeatherInfoSection(
             Image(
                 modifier = Modifier
                     .testTag("weather_icon")
-                    .fillMaxWidth()
+                    .weight(1f, false)
                     .aspectRatio(1f),
                 painter = painterResource(weatherIcon),
                 contentDescription = "Weather Icon",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,6 @@ androidxAppCompat = "1.7.0"
 androidxActivity = "1.9.1"
 androidxLifecycle = "2.8.4"
 androidxCompose = "2024.08.00"
-androidxComposeConstraintLayout = "0.4.0"
 androidxNavigation = "2.7.7"
 
 # Google
@@ -121,7 +120,6 @@ compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-material-icons = { module = "androidx.compose.material:material-icons-extended" }
-compose-constraint-layout = { module = "tech.annexflow.compose:constraintlayout-compose-multiplatform", version.ref = "androidxComposeConstraintLayout" }
 
 # Google
 material = { module = "com.google.android.material:material", version.ref = "material" }


### PR DESCRIPTION
## 修正内容
- #61 
- https://github.com/matsumo0922/android-training-template/pull/62#issuecomment-2311785937 で頂いたレビューに対応します
  - 現状、ホーム画面のレイアウトは横向き時を考慮されておらず、端末を横向きにした時や Wasm で実行したときに不恰好となります
  - そのため「天気アイコンを画面中央に表示する」という仕様を破棄し、画面の最大高さに応じて天気アイコンの大きさ位置を自動的に調整できるように変更します

## レビューレベルの設定
<!--
希望するレビューレベルにチェックをつけてください。[x]のように小文字エックスを入れるとチェックがつきます。
-->

- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [x] ぱっとみて違和感がないかチェックしてApproveする
- [ ] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点
- 横向き時でも違和感がないか

## スクリーンショット
| After |
| - |
|<video src=https://github.com/user-attachments/assets/251183bf-ae07-44db-88f8-4eb66bbf6e8d >|


## 備考
- N/A
