### PR TITLE
Add GitHub Actions CD about to deploy wasm for GitHub Pages

### DIFF
--- a/.github/workflows/push-deploy-wasm.yml
+++ b/.github/workflows/push-deploy-wasm.yml
@@ -1,0 +1,40 @@
+name: Deploy wasm
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-wasm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Generate Artifact
+        run: ./gradlew :app:wasmJsBrowserDistribution
+
+      - name: Deploy coverage
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: "./app/build/dist/wasmJs/productionExecutable"
+          destination_dir: "./"

--- a/.github/workflows/push-deploy-wasm.yml
+++ b/.github/workflows/push-deploy-wasm.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Generate Artifact
         run: ./gradlew :app:wasmJsBrowserDistribution
 
-      - name: Deploy coverage
+      - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 修正内容
- closes #61 
- main にプッシュした時に自動で wasm ターゲットのアプリを GitHub Pages にデプロイするジョブを作成します

## レビューレベルの設定
- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [x] ぱっとみて違和感がないかチェックしてApproveする
- [ ] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点
- 正しくデプロイされるか

## スクリーンショット
- N/A

## 備考
- N/A
