### PR TITLE
[skip ci] Fix CD about add keep_files params

### DIFF
--- a/.github/workflows/push-deploy-wasm.yml
+++ b/.github/workflows/push-deploy-wasm.yml
@@ -38,3 +38,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: "./app/build/dist/wasmJs/productionExecutable"
           destination_dir: "./"
+          keep_files: true


### PR DESCRIPTION
## 修正内容
- `keep_files` を指定しなかったことにより、過去のデプロイ履歴が消えてしまうため `keep_files` を指定するようにします


## レビューレベルの設定
<!--
希望するレビューレベルにチェックをつけてください。[x]のように小文字エックスを入れるとチェックがつきます。
-->

- [ ] まったく見ないでApproveする(基本的には非推奨。)
- [x] ぱっとみて違和感がないかチェックしてApproveする
- [ ] 仕様レベルまで理解して、仕様通りに動くかある程度検証、動作確認までしてApproveする
- [ ] その他 (以下にコメント記載)

## レビュー観点
- N/A

## スクリーンショット
- N/A

## 備考
- N/A
